### PR TITLE
Added updated kit code for sending events

### DIFF
--- a/mParticle-Taplytics/MPKitTaplytics.m
+++ b/mParticle-Taplytics/MPKitTaplytics.m
@@ -96,7 +96,7 @@ static NSString * const SHOW_LAUNCH_IMAGE_TYPE = @"TaplyticsOptionShowLaunchImag
             [Taplytics startTaplyticsAPIKey:apiKey options:options];
         }
     });
-    
+
     self->_started = YES;
 
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -202,14 +202,13 @@ static NSString * const SHOW_LAUNCH_IMAGE_TYPE = @"TaplyticsOptionShowLaunchImag
 - (MPKitExecStatus *)routeCommerceEvent:(MPCommerceEvent *)commerceEvent {
     MPKitExecStatus *execStatus = [self createStatus:MPKitReturnCodeSuccess];
 
-    // In this example, this SDK only supports the 'Purchase' commerce event action
     if (commerceEvent.action == MPCommerceEventActionPurchase) {
         MPTransactionAttributes *transaction = commerceEvent.transactionAttributes;
         if (transaction != nil && transaction.revenue != nil && transaction.transactionId != nil) {
             [Taplytics logRevenue:transaction.transactionId revenue:transaction.revenue];
             [execStatus incrementForwardCount];
         }
-    } else { // Other commerce events are expanded and logged as regular events
+    } else {
         NSArray *expandedInstructions = [commerceEvent expandedInstructions];
 
         for (MPCommerceEventInstruction *commerceEventInstruction in expandedInstructions) {

--- a/mParticle-Taplytics/MPKitTaplytics.m
+++ b/mParticle-Taplytics/MPKitTaplytics.m
@@ -224,10 +224,12 @@ static NSString * const SHOW_LAUNCH_IMAGE_TYPE = @"TaplyticsOptionShowLaunchImag
 - (MPKitExecStatus *)routeEvent:(MPEvent *)event {
     NSString * eventName = event.name;
     NSDictionary * metaData = event.customAttributes;
-    if (metaData != nil) {
-        [Taplytics logEvent:eventName value:nil metaData:metaData];
-    } else if (eventName != nil) {
-        [Taplytics logEvent:eventName];
+    if (eventName != nil) {
+        if (metaData != nil) {
+            [Taplytics logEvent:eventName value:nil metaData:metaData];
+        } else {
+            [Taplytics logEvent:eventName];
+        }
     } else {
         return [self createStatus:MPKitReturnCodeFail];
     }


### PR DESCRIPTION
## Summary

Updated methods that were deprecated to the new usage of `routeEvent`, `routeCommerceEvent` and `logBaseEvent`. Also fixed an issue where the old code was expecting metadata on every `MPEvent`, so no events were sending recently because events no longer (or never did) have metadata attached to events unless explicitly put on by the user.