### PR TITLE
chore: update taplytics to use latest 4.0 build that uses xcframework

### DIFF
--- a/mParticle-Taplytics.podspec
+++ b/mParticle-Taplytics.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "9.0"
     s.ios.source_files      = 'mParticle-Taplytics/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
-    s.ios.dependency 'Taplytics', '~> 3.0'
+    s.ios.dependency 'Taplytics', '~> 4.0'
 
     s.ios.pod_target_xcconfig = {
         'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'


### PR DESCRIPTION
# Summary

Updated to `4.0` version that uses `xcframework` to build.