### PR TITLE
fix: Header imports for mParticle SDK

### DIFF
--- a/mParticle-Taplytics/MPKitTaplytics.h
+++ b/mParticle-Taplytics/MPKitTaplytics.h
@@ -1,9 +1,14 @@
 #import <Foundation/Foundation.h>
 
 #if defined(__has_include) && __has_include(<mParticle_Apple_SDK/mParticle.h>)
-#import <mParticle_Apple_SDK/mParticle.h>
+    #import <mParticle_Apple_SDK/mParticle.h>
+    #import <mParticle_Apple_SDK/mParticle_Apple_SDK-Swift.h>
+#elif defined(__has_include) && __has_include(<mParticle_Apple_SDK_NoLocation/mParticle.h>)
+    #import <mParticle_Apple_SDK_NoLocation/mParticle.h>
+    #import <mParticle_Apple_SDK_NoLocation/mParticle_Apple_SDK-Swift.h>
 #else
-#import "mParticle.h"
+    #import "mParticle.h"
+    #import "mParticle_Apple_SDK-Swift.h"
 #endif
 
 @interface MPKitTaplytics : NSObject <MPKitProtocol>


### PR DESCRIPTION
## Summary
Adds headers for accessing public Swift classes in the core SDK. Marked as fix so semantic release will make a patch version bump instead of minor version bump.

## Testing Instructions
Tested by compiling and running a local app to see that there were no header or Swift related errors.